### PR TITLE
fix(cgo): type String/Vector pointer fields as uintptr_t 

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1500,8 +1500,8 @@ typedef unsigned short char16_t;
 extern "C" {
 #endif
 
-typedef struct String { char* data; size_t size; size_t cap; } String;
-typedef struct Vector { void* begin; void* end; void* capacity; } Vector;
+typedef struct String { uintptr_t data; size_t size; size_t cap; } String;
+typedef struct Vector { uintptr_t begin; uintptr_t end; uintptr_t capacity; } Vector;
 typedef struct Vector2 { float x, y; } Vector2;
 typedef struct Vector3 { float x, y, z; } Vector3;
 typedef struct Vector4 { float x, y, z, w; } Vector4;

--- a/plugify.h
+++ b/plugify.h
@@ -17,8 +17,8 @@ extern "C" {
 #endif
 
 typedef struct GoString_ { const char* p; ptrdiff_t n; } GoString_;
-typedef struct String { char* data; size_t size; size_t cap; } String;
-typedef struct Vector { void* begin; void* end; void* capacity; } Vector;
+typedef struct String { uintptr_t data; size_t size; size_t cap; } String;
+typedef struct Vector { uintptr_t begin; uintptr_t end; uintptr_t capacity; } Vector;
 typedef struct Vector2 { float x, y; } Vector2;
 typedef struct Vector3 { float x, y, z; } Vector3;
 typedef struct Vector4 { float x, y, z, w; } Vector4;


### PR DESCRIPTION
fix(cgo): type String/Vector pointer fields as uintptr_t to stop GC false-positive "pointer to free object"